### PR TITLE
Replace Clerk with Auth0 as our auth solution

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -11,8 +11,7 @@
     "format": "prettier --write ."
   },
   "dependencies": {
-    "@clerk/clerk-react": "^4.28.3",
-    "@clerk/themes": "^1.7.9",
+    "@auth0/auth0-react": "^2.2.3",
     "@fontsource-variable/inter": "^5.0.15",
     "@tanstack/react-query": "^4.3.9",
     "@trpc/client": "10.44.1",

--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -7,28 +7,21 @@ import { Route, Switch } from "wouter";
 import { Hello } from "./pages/Hello";
 import { Overview } from "./pages/Overview";
 import { Nav } from "./components/Nav";
-import { ClerkProvider } from "@clerk/clerk-react";
 import { SignIn } from "./pages/SignIn";
-import { SignUp } from "./pages/SignUp";
-import { dark } from "@clerk/themes";
-
-const clerkPublishableKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY;
-
-if (!clerkPublishableKey) {
-  throw new Error("Missing Publishable Key");
-}
+import { Auth0Provider } from "@auth0/auth0-react";
 
 export function App() {
   return (
     <WithTrpc>
-      <ClerkProvider
-        publishableKey={clerkPublishableKey}
-        appearance={{
-          baseTheme: dark,
+      <Auth0Provider
+        domain={import.meta.env.VITE_AUTH0_DOMAIN}
+        clientId={import.meta.env.VITE_AUTH0_CLIENT_ID}
+        authorizationParams={{
+          redirect_uri: window.location.origin,
         }}
       >
         <Router />
-      </ClerkProvider>
+      </Auth0Provider>
     </WithTrpc>
   );
 }
@@ -61,7 +54,6 @@ function Router() {
         <Route path="/hello" component={Hello} />
         <Route path="/" component={Overview} />
         <Route path="/signin" component={SignIn} />
-        <Route path="/signup" component={SignUp} />
         <Route>404, Not Found!</Route>
       </Switch>
     </>

--- a/apps/admin/src/components/Nav.tsx
+++ b/apps/admin/src/components/Nav.tsx
@@ -19,9 +19,6 @@ export function Nav() {
         <li>
           <Link href="/signin">Sign In</Link>
         </li>
-        <li>
-          <Link href="/signup">Sign Up</Link>
-        </li>
       </ul>
     </div>
   );

--- a/apps/admin/src/pages/SignIn.tsx
+++ b/apps/admin/src/pages/SignIn.tsx
@@ -1,5 +1,12 @@
-import { SignIn as ClerkSignIn } from "@clerk/clerk-react";
+import { useAuth0 } from "@auth0/auth0-react";
+import { Redirect } from "wouter";
 
 export function SignIn() {
-  return <ClerkSignIn />;
+  const { isLoading, isAuthenticated, loginWithRedirect } = useAuth0();
+  if (isLoading) return <div>Loading...</div>;
+
+  // Redirect to home if the user is authenticated
+  if (isAuthenticated) return <Redirect to="/" />;
+
+  return <button onClick={() => loginWithRedirect()}>Sign In</button>;
 }

--- a/apps/admin/src/pages/SignUp.tsx
+++ b/apps/admin/src/pages/SignUp.tsx
@@ -1,5 +1,0 @@
-import { SignUp as ClerkSignUp } from "@clerk/clerk-react";
-
-export function SignUp() {
-  return <ClerkSignUp />;
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,12 +27,9 @@ importers:
 
   apps/admin:
     dependencies:
-      '@clerk/clerk-react':
-        specifier: ^4.28.3
-        version: 4.28.3(react@18.2.0)
-      '@clerk/themes':
-        specifier: ^1.7.9
-        version: 1.7.9(react@18.2.0)
+      '@auth0/auth0-react':
+        specifier: ^2.2.3
+        version: 2.2.3(react-dom@18.2.0)(react@18.2.0)
       '@fontsource-variable/inter':
         specifier: ^5.0.15
         version: 5.0.15
@@ -226,6 +223,21 @@ packages:
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.19
     dev: true
+
+  /@auth0/auth0-react@2.2.3(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-3B0KA/ky1yA6iQK8045N8U0ZBkmDB3ElCSwJuxNbAoKmZBc4+DjzZhWRxYsgb9PrfHC14Lr2h4950A3PEFDULA==}
+    peerDependencies:
+      react: ^16.11.0 || ^17 || ^18
+      react-dom: ^16.11.0 || ^17 || ^18
+    dependencies:
+      '@auth0/auth0-spa-js': 2.1.2
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /@auth0/auth0-spa-js@2.1.2:
+    resolution: {integrity: sha512-xdA65Z/U7++Y7L9Uwh8Q8OVOs6qgFz+fb7GAzHFjpr1icO37B//xdzLXm7ZRgA19RWrsNe1nme3h896igJSvvw==}
+    dev: false
 
   /@babel/code-frame@7.22.10:
     resolution: {integrity: sha512-/KKIMG4UEL35WmI9OlvMhurwtytjvXoFcGNrOvyG9zIzA8YmPjVtIZUf7b05+TPO7G7/GEmLHDaoCgACHl9hhA==}
@@ -445,48 +457,6 @@ packages:
       '@babel/helper-validator-identifier': 7.22.5
       to-fast-properties: 2.0.0
     dev: true
-
-  /@clerk/clerk-react@4.28.3(react@18.2.0):
-    resolution: {integrity: sha512-keiQSpl9EVP7XNKOLXRs+zxkrGG8FRueMdn0+GcOUlmfIUcE9HFhCX/2wCt7OiLuuZLJpMOVEg9weDepW5APEg==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      react: '>=16'
-    dependencies:
-      '@clerk/shared': 1.1.1(react@18.2.0)
-      '@clerk/types': 3.58.1
-      react: 18.2.0
-      tslib: 2.4.1
-    dev: false
-
-  /@clerk/shared@1.1.1(react@18.2.0):
-    resolution: {integrity: sha512-pEzhalD1Yo/gGsOE2BQugVQTjlIl2aYmoeRld3BDXHRDV1jnk+yUE2CFOw6bojgFWN9sbeN/ph/47UWvvoCSOg==}
-    peerDependencies:
-      react: '>=16'
-    peerDependenciesMeta:
-      react:
-        optional: true
-    dependencies:
-      glob-to-regexp: 0.4.1
-      js-cookie: 3.0.1
-      react: 18.2.0
-      swr: 2.2.0(react@18.2.0)
-    dev: false
-
-  /@clerk/themes@1.7.9(react@18.2.0):
-    resolution: {integrity: sha512-9hXxgoPuUSlZ7sH9diJEK1rTWEnk0zGKBYw4Tqaqp0RA1dtB+OHE02DK5pnTypZTnreBJYac3VmxFVTxVV35xg==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      react: '>=16'
-    dependencies:
-      react: 18.2.0
-    dev: false
-
-  /@clerk/types@3.58.1:
-    resolution: {integrity: sha512-cumryWXAYNCApsc3pmuHiJQnhUcNuQPCMI8w/bVU9VuGm9Ry0zhCWawD7F3/VWAOnAPu4ghKrwEaLkGsiSsY2Q==}
-    engines: {node: '>=14'}
-    dependencies:
-      csstype: 3.1.1
-    dev: false
 
   /@cloudflare/kv-asset-handler@0.2.0:
     resolution: {integrity: sha512-MVbXLbTcAotOPUj0pAMhVtJ+3/kFkwJqc5qNOleOZTv6QkZZABDMS21dSrSlVswEHwrpWC03e4fWytjqKvuE2A==}
@@ -2975,10 +2945,6 @@ packages:
     hasBin: true
     dev: true
 
-  /csstype@3.1.1:
-    resolution: {integrity: sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==}
-    dev: false
-
   /csstype@3.1.2:
     resolution: {integrity: sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==}
     dev: true
@@ -4700,6 +4666,7 @@ packages:
 
   /glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
+    dev: true
 
   /glob@7.1.6:
     resolution: {integrity: sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==}
@@ -5384,11 +5351,6 @@ packages:
   /jju@1.4.0:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
     dev: true
-
-  /js-cookie@3.0.1:
-    resolution: {integrity: sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==}
-    engines: {node: '>=12'}
-    dev: false
 
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -7232,15 +7194,6 @@ packages:
       upper-case: 1.1.3
     dev: true
 
-  /swr@2.2.0(react@18.2.0):
-    resolution: {integrity: sha512-AjqHOv2lAhkuUdIiBu9xbuettzAzWXmCEcLONNKJRba87WAefz8Ca9d6ds/SzrPc235n1IxWYdhJ2zF3MNUaoQ==}
-    peerDependencies:
-      react: ^16.11.0 || ^17.0.0 || ^18.0.0
-    dependencies:
-      react: 18.2.0
-      use-sync-external-store: 1.2.0(react@18.2.0)
-    dev: false
-
   /synckit@0.8.5:
     resolution: {integrity: sha512-L1dapNV6vu2s/4Sputv8xGsCdAVlb5nRDMFU/E27D44l5U6cw1g0dGd45uLc+OXjNMmF4ntiMdCimzcjFKQI8Q==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -7488,10 +7441,6 @@ packages:
   /tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
     dev: true
-
-  /tslib@2.4.1:
-    resolution: {integrity: sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==}
-    dev: false
 
   /tslib@2.5.0:
     resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}


### PR DESCRIPTION
Clerk doesn't allow domain-based registration on their free tier, meaning anyone who comes across the admin site can create an account. Auth0 allows this through "Actions". With actions, we can easily create a pre-registration flow to only allow users with a KnightHacks email to register an account on the site.

![image](https://github.com/KnightHacks/knighthacks/assets/72979586/b91442b6-29b3-42fe-b60e-43aa234fce43)
