### PR TITLE
Set up prod and dev environment configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@ yarn-error.log*
 .env.development.local
 .env.test.local
 .env.production.local
+.env.prod
+.env.dev
 
 # turbo
 .turbo

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "license": "MIT",
   "scripts": {
-    "with-env": "dotenv -e .env --",
+    "with-env": "dotenv -e .env.dev --",
     "test": "turbo run test",
     "build": "pnpm with-env turbo run build",
     "deploy": "turbo run deploy",

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalDotEnv": [".env"],
+  "globalDotEnv": [".env.dev"],
   "pipeline": {
     "topo": {
       "dependsOn": ["^topo"]


### PR DESCRIPTION
This PR changes the way we handle environment variables in the monorepo. Currently, we only handle one environment variable configuration file: .env, typically for development. This PR sets up the monorepo to handle an env file for prod and dev. This allows you to switch between locally hosting the prod environment and your dev environment. The default env configuration is for development i.e. .env.dev.

**NOTE: The only way to "switch" between these environments is to change `"with-env": "dotenv -e .env.dev --"` to `"with-env": "dotenv -e .env.prod --"`.** We should definitely find a better way to switch between to switch between these two contexts, maybe through a CLI tool.