### PR TITLE
Fix env vars in CI for API deployment

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -26,14 +26,14 @@ jobs:
           command: deploy
           packageManager: pnpm
           secrets: |
-            TURSO_URL
-            TURSO_AUTH_TOKEN
+            DATABASE_URL
+            DATABASE_AUTH_TOKEN
             CLERK_SECRET_KEY
             CLERK_PUBLISHABLE_KEY
             CLERK_WEBHOOK_SECRET_KEY
         env:
-          TURSO_URL: ${{ secrets.TURSO_URL }}
-          TURSO_AUTH_TOKEN: ${{ secrets.TURSO_AUTH_TOKEN }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          DATABASE_AUTH_TOKEN: ${{ secrets.DATABASE_AUTH_TOKEN }}
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
           CLERK_PUBLISHABLE_KEY: ${{ secrets.CLERK_PUBLISHABLE_KEY }}
           CLERK_WEBHOOK_SECRET_KEY: ${{secrets.CLERK_WEBHOOK_SECRET_KEY}}


### PR DESCRIPTION
Currently, our GitHub actions reads TURSO_URL and TURSO_AUTH_TOKEN instead of DATABASE_URL and DATABASE_AUTH_TOKEN