### PR TITLE
Update NextJs Config + remove rounding in sponsors

### DIFF
--- a/apps/2024/next.config.mjs
+++ b/apps/2024/next.config.mjs
@@ -8,6 +8,16 @@ createJiti(fileURLToPath(import.meta.url))("./src/env");
 const config = {
   reactStrictMode: true,
 
+  /** Allow images from all domains so sponsor images dont get blocked */
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "**",
+      },
+    ],
+  },
+
   /** Enables hot reloading for local packages without a build step */
   transpilePackages: [
     "@knighthacks/api",

--- a/apps/2024/src/app/(main)/_components/sections/sponsors.tsx
+++ b/apps/2024/src/app/(main)/_components/sections/sponsors.tsx
@@ -49,9 +49,8 @@ export async function Sponsors() {
                         <Image
                           width={imageSize}
                           height={imageSize}
-                          src={sponsor.logo}
+                          src={sponsor.logo}g
                           alt={sponsor.name}
-                          className="rounded-full"
                         />
                       </a>
                     </section>

--- a/apps/2024/src/app/(main)/_components/sections/sponsors.tsx
+++ b/apps/2024/src/app/(main)/_components/sections/sponsors.tsx
@@ -18,12 +18,15 @@ export async function Sponsors() {
   };
 
   return (
-    <section id="sponsors" className="flex items-center justify-center">
+    <section
+      id="sponsors"
+      className="flex items-center justify-center overflow-hidden pt-44 md:pt-96"
+    >
       <div className="flex flex-col">
-        <h1 className="font-k2d w-[405px]text-center h-[125px] text-center text-[96px] font-bold leading-[125px] text-[#FFD166]">
+        <h1 className="font-k2d h-[125px] w-full pb-14 text-center text-7xl font-bold leading-[125px] text-[#FFD166] md:text-[96px]">
           Sponsors
         </h1>
-        <div className="grid h-auto max-w-full auto-rows-auto grid-cols-1 gap-4 overflow-hidden sm:grid-cols-2 md:auto-rows-[275px] md:grid-cols-4">
+        <div className="grid max-w-full auto-rows-auto grid-cols-1 gap-4 overflow-hidden sm:grid-cols-2 md:h-screen md:auto-rows-[275px] md:grid-cols-4">
           {sponsors.map((sponsor, index) => {
             const { bubbleSize, imageSize, cellSize } = getSizes(sponsor);
             const delay = Math.random() * 2;

--- a/apps/2024/src/app/(main)/_components/sections/sponsors.tsx
+++ b/apps/2024/src/app/(main)/_components/sections/sponsors.tsx
@@ -49,7 +49,7 @@ export async function Sponsors() {
                         <Image
                           width={imageSize}
                           height={imageSize}
-                          src={sponsor.logo}g
+                          src={sponsor.logo}
                           alt={sponsor.name}
                         />
                       </a>


### PR DESCRIPTION
- all domains are now allowed for Next Images to accommodate for external sponsor images
- removed a styling issue for the sponsor bubbles
![image](https://github.com/KnightHacks/knighthacks/assets/111909137/d96a245e-ad68-4729-a411-ad5b64921c10)
